### PR TITLE
javascript:; rather than #

### DIFF
--- a/resources/js/input.js
+++ b/resources/js/input.js
@@ -1,0 +1,17 @@
+$(function () {
+
+    // Initialize the encrypted inputs.
+    $('.encrypted-field-type').each(function () {
+
+        var wrapper = $(this);
+
+        // Toggle text
+        wrapper.on('click', '[data-toggle="text"]', function () {
+            if (wrapper.find('input').attr('type') == 'password') {
+                wrapper.find('input').attr('type', 'text');
+            } else {
+                wrapper.find('input').attr('type', 'password');
+            }
+        });
+    });
+});

--- a/resources/lang/en/input.php
+++ b/resources/lang/en/input.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    'show_text' => 'Show text'
+    'toggle_text' => 'Toggle text'
 ];

--- a/resources/views/input.twig
+++ b/resources/views/input.twig
@@ -10,7 +10,7 @@
         {{ field_type.readonly ? 'readonly' }}>
 
 {% if not field_type.config.show_text %}
-    <a href="#" data-toggle="text">
+    <a href="javascript:;" data-toggle="text">
         <small>{{ trans('anomaly.field_type.encrypted::input.toggle_text') }}</small>
     </a>
 {% endif %}

--- a/resources/views/input.twig
+++ b/resources/views/input.twig
@@ -1,3 +1,5 @@
+{{ asset_add('scripts.js', 'anomaly.field_type.encrypted::js/input.js') }}
+
 <input
         class="form-control"
         name="{{ field_type.input_name }}"
@@ -8,7 +10,7 @@
         {{ field_type.readonly ? 'readonly' }}>
 
 {% if not field_type.config.show_text %}
-    <a href="#" onclick="$(this).closest('div').find('input').attr('type', 'text'); return false;">
-        <small>{{ trans('anomaly.field_type.encrypted::input.show_text') }}</small>
+    <a href="#" data-toggle="text">
+        <small>{{ trans('anomaly.field_type.encrypted::input.toggle_text') }}</small>
     </a>
 {% endif %}


### PR DESCRIPTION
Using javascript:; rather than # prevents the link from jumping to the top of the page when it is clicked on
